### PR TITLE
change user to root in program:oust

### DIFF
--- a/supervisor/conf.d/joust.conf
+++ b/supervisor/conf.d/joust.conf
@@ -8,6 +8,6 @@ startretries=1000
 command=/usr/bin/python /home/pi/psmoveapi/build/oust.py
 directory=/home/pi/psmoveapi/build
 environment=HOME="/home/pi"
-user=pi
+user=root
 autorestart=true
 startretries=1000


### PR DESCRIPTION
I found out that the psmove API calls don't work if python isn't run as root. Dunno why and it was painful to find out but still, it works.
