### PR TITLE
Add support for multiple adapters/more than 8 controllers.

### DIFF
--- a/scan_enable.sh
+++ b/scan_enable.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 echo "Watching hci devices..."
 
 while true; do
-    devices=$(hciconfig dev | grep hci | awk '{print $1}' | sed -e 's/://')
+    devices=$(hciconfig | grep hci | awk '{print $1}' | sed -e 's/://')
 
     for device in $devices
     do


### PR DESCRIPTION
One main problem with not being able to use more than 8 controllers
at once was the fact that each adapter can only handle about 6-7
controllers.

The move.pair() function seemed to always just pair controllers
to the default adapter, thus filling up a single hci device in /var/lib/bluetooth

This change loops through all of the connected adapters as seen by
hciconfig, and pairs the move controller with the adapter with the
smallest connected controller count using the move.pair_custom() function.
Thus allowing for an even spread among the different bluetooth adapters.

also removed the dev in scan_enable, since hciconfig dev, doesn't seem
to list out all of the connected adapters, while hciconfig by itself
does

When testing this on my Pi2 there also seems to be some issues with the bluetooth service restarting
sometimes with multi-adapter use, I'm not sure what the problem is
as I've been able to connect 16 controllers to the pi successfully before. 
Using a single adapter seems to still be stable as it was before, It might be good to try
loading oust manually rather than from the image to see if that helps, as well as loading it up on a pi3